### PR TITLE
feat: add stalled task timeout feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,19 @@ build:
   command: go build .
   watch: src/
 ```
+### Stalled Tasks
+
+Tasks are considered stalled if they do not output anything for 30s by default. You can change this with the `stalledTimeout` field:
+
+```yaml
+build:
+  command: go build .
+  stalledTimeout: 1m
+```
+
+You might wish to reduce this if the task waits for the user to do something.
+
+You might wish to increase this if the task does not output much.
 
 ### Targets
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -8,6 +8,8 @@
 
 ### Objects
 
+*   [Duration](./workflow-defs-duration.md) – `https://github.com/kitproj/kit/internal/types/workflow#/$defs/Duration`
+
 *   [EnvVars](./workflow-defs-envvars.md "A list of environment variables") – `https://github.com/kitproj/kit/internal/types/workflow#/$defs/EnvVars`
 
 *   [HTTPGetAction](./workflow-defs-httpgetaction.md "HTTPGetAction describes an action based on HTTP Locks requests") – `https://github.com/kitproj/kit/internal/types/workflow#/$defs/HTTPGetAction`

--- a/docs/reference/workflow-defs-task.md
+++ b/docs/reference/workflow-defs-task.md
@@ -42,6 +42,7 @@ A task is a container or a command to run.
 | [dependencies](#dependencies)       | `array`   | Optional | cannot be null | [Untitled schema](workflow-defs-strings.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Task/properties/dependencies")                            |
 | [targets](#targets)                 | `array`   | Optional | cannot be null | [Untitled schema](workflow-defs-strings.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Task/properties/targets")                                 |
 | [restartPolicy](#restartpolicy)     | `string`  | Optional | cannot be null | [Untitled schema](workflow-defs-task-properties-restartpolicy.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Task/properties/restartPolicy")     |
+| [stalledTimeout](#stalledtimeout)   | `object`  | Optional | cannot be null | [Untitled schema](workflow-defs-duration.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Task/properties/stalledTimeout")                         |
 
 ## type
 
@@ -476,3 +477,21 @@ The restart policy, e.g. Always, Never, OnFailure. Defaults depends on the type 
 ### restartPolicy Type
 
 `string` ([restartPolicy](workflow-defs-task-properties-restartpolicy.md))
+
+## stalledTimeout
+
+The timeout for the task to be considered stalled. If omitted, the task will be considered stalled after 30 seconds of no activity.
+
+`stalledTimeout`
+
+*   is optional
+
+*   Type: `object` ([Duration](workflow-defs-duration.md))
+
+*   cannot be null
+
+*   defined in: [Untitled schema](workflow-defs-duration.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Task/properties/stalledTimeout")
+
+### stalledTimeout Type
+
+`object` ([Duration](workflow-defs-duration.md))

--- a/docs/reference/workflow.md
+++ b/docs/reference/workflow.md
@@ -16,6 +16,36 @@ unknown
 
 # Untitled schema Definitions
 
+## Definitions group Duration
+
+Reference this group by using
+
+```json
+{"$ref":"https://github.com/kitproj/kit/internal/types/workflow#/$defs/Duration"}
+```
+
+| Property              | Type     | Required | Nullable       | Defined by                                                                                                                                |
+| :-------------------- | :------- | :------- | :------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| [Duration](#duration) | `object` | Required | cannot be null | [Untitled schema](workflow-defs-duration.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Duration/properties/Duration") |
+
+### Duration
+
+
+
+`Duration`
+
+*   is required
+
+*   Type: `object` ([Duration](workflow-defs-duration.md))
+
+*   cannot be null
+
+*   defined in: [Untitled schema](workflow-defs-duration.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Duration/properties/Duration")
+
+#### Duration Type
+
+`object` ([Duration](workflow-defs-duration.md))
+
 ## Definitions group EnvVars
 
 Reference this group by using
@@ -415,6 +445,7 @@ Reference this group by using
 | [dependencies](#dependencies)       | `array`   | Optional | cannot be null | [Untitled schema](workflow-defs-strings.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Task/properties/dependencies")                            |
 | [targets](#targets)                 | `array`   | Optional | cannot be null | [Untitled schema](workflow-defs-strings.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Task/properties/targets")                                 |
 | [restartPolicy](#restartpolicy)     | `string`  | Optional | cannot be null | [Untitled schema](workflow-defs-task-properties-restartpolicy.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Task/properties/restartPolicy")     |
+| [stalledTimeout](#stalledtimeout)   | `object`  | Optional | cannot be null | [Untitled schema](workflow-defs-duration.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Task/properties/stalledTimeout")                         |
 
 ### type
 
@@ -849,6 +880,24 @@ The restart policy, e.g. Always, Never, OnFailure. Defaults depends on the type 
 #### restartPolicy Type
 
 `string` ([restartPolicy](workflow-defs-task-properties-restartpolicy.md))
+
+### stalledTimeout
+
+The timeout for the task to be considered stalled. If omitted, the task will be considered stalled after 30 seconds of no activity.
+
+`stalledTimeout`
+
+*   is optional
+
+*   Type: `object` ([Duration](workflow-defs-duration.md))
+
+*   cannot be null
+
+*   defined in: [Untitled schema](workflow-defs-duration.md "https://github.com/kitproj/kit/internal/types/workflow#/$defs/Task/properties/stalledTimeout")
+
+#### stalledTimeout Type
+
+`object` ([Duration](workflow-defs-duration.md))
 
 ## Definitions group Tasks
 

--- a/internal/index.html
+++ b/internal/index.html
@@ -77,6 +77,10 @@
             animation: pulse 2s infinite;
         }
 
+        .node.stalled rect {
+            fill: #Fcf;
+        }
+
         .node.skipped rect {
             fill: #eee;
         }
@@ -177,12 +181,14 @@
     const check = '<path d="M2 8l4 4 8-8" stroke="#FFF" fill="none" stroke-width="4"/>';
     const cross = '<path d="M3 3l10 10m0-10L3 13" stroke="#FFF" stroke-width="4"/>'
     const skip = '<path d="M5 2l6 6-6 6" stroke="#FFF" stroke-width="4" fill="none"/>'
+    const idle = '<path d="M3,8 L5,8 M7,8 L9,8 M11,8 L13,8" stroke="#fff" stroke-width="4"/>'
 
     const icons = {
         waiting: pause,
         pending: pause,
         starting: play,
         running: play,
+        stalled: idle,
         failed: cross,
         succeeded: check,
         skipped: skip,

--- a/internal/task_node.go
+++ b/internal/task_node.go
@@ -11,7 +11,7 @@ type TaskNode struct {
 	task types.Task
 	// logFile is the log file path
 	logFile string
-	// the phase of the task, e.g. "pending", "waiting", "running", "succeeded", "failed", "cancelled", "skipped"
+	// the phase of the task, e.g. "pending", "waiting", "running", "stalled", "succeeded", "failed", "cancelled", "skipped"
 	Phase string `json:"phase"`
 	// the message for the task phase, e.g. "exit code 1'
 	Message string `json:"message,omitempty"`
@@ -23,7 +23,7 @@ type TaskNode struct {
 
 func (n TaskNode) blocked() bool {
 	switch n.Phase {
-	case "running":
+	case "running", "stalled":
 		return n.task.GetType() == types.TaskTypeJob
 	case "succeeded", "skipped":
 		return false

--- a/internal/types/task.go
+++ b/internal/types/task.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (t *Task) HasMutex() bool {
@@ -62,6 +64,8 @@ type Task struct {
 	Targets Strings `json:"targets,omitempty"`
 	// The restart policy, e.g. Always, Never, OnFailure. Defaults depends on the type of task.
 	RestartPolicy string `json:"restartPolicy,omitempty"`
+	// The timeout for the task to be considered stalled. If omitted, the task will be considered stalled after 30 seconds of no activity.
+	StalledTimeout *metav1.Duration `json:"stalledTimeout,omitempty"`
 }
 
 func (t Task) IsBackground() bool {
@@ -188,4 +192,11 @@ func (t *Task) GetType() TaskType {
 	}
 	return TaskTypeJob
 
+}
+
+func (t *Task) GetStalledTimeout() time.Duration {
+	if t.StalledTimeout != nil {
+		return t.StalledTimeout.Duration
+	}
+	return 30 * time.Second
 }

--- a/schema/workflow.schema.json
+++ b/schema/workflow.schema.json
@@ -3,6 +3,20 @@
   "$id": "https://github.com/kitproj/kit/internal/types/workflow",
   "$ref": "#/$defs/Workflow",
   "$defs": {
+    "Duration": {
+      "properties": {
+        "Duration": {
+          "$ref": "#/$defs/Duration",
+          "title": "Duration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Duration"
+      ],
+      "title": "Duration"
+    },
     "EnvVars": {
       "patternProperties": {
         ".*": {
@@ -269,6 +283,11 @@
           "type": "string",
           "title": "restartPolicy",
           "description": "The restart policy, e.g. Always, Never, OnFailure. Defaults depends on the type of task."
+        },
+        "stalledTimeout": {
+          "$ref": "#/$defs/Duration",
+          "title": "stalledTimeout",
+          "description": "The timeout for the task to be considered stalled. If omitted, the task will be considered stalled after 30 seconds of no activity."
         }
       },
       "additionalProperties": false,

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -17,8 +17,9 @@ tasks:
       set -eux
       for i in {1..1000}; do
         echo "hello $i"
-        sleep 1
+        sleep 2
       done
+    stalledTimeout: 1s
   run-app:
     command:
     - ./demo/go/go


### PR DESCRIPTION
This pull request changes:

- Implements a `stalledTimeout` feature for tasks to determine when they are considered stalled, with configurable timeout settings.
- Updates the documentation to reflect the new `stalledTimeout` property in task definitions and adds an explanation of how to use it.
- Modifies the internal task handling logic to account for stalled tasks, including visual updates for stalled task states.

Code review suggestions:

- Consider reviewing the logic behind the handling of the `stalledTimeout` functionality to ensure performance efficiency, particularly in the usage of timers.
- Ensure that all new functionality is adequately tested, including cases with various `stalledTimeout` settings and their impact on task states.
- Review code comments for clarity and completeness, especially around the new sections introduced for handling stalled tasks.