### PR TITLE
docs(kit): clarify job and service restart policies and improve task …

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,25 @@ service:
 ```
 
 The ports will be forwarded from the host to the service. A service will be restarted if it does not start-up (i.e. it
-is listening on the port).
+is listening on the port), or it exits with an error (non-zero exit code).
+
+Jobs, on the other hand, are not restarted if they error.
+
+You can override this by setting `restartPolicy` to `Never`:
+
+```yaml
+job:
+  command: go run .
+  # Always, Never, OnFailure
+  # jobs default to Never
+  # services default to Always
+  restartPolicy: Never
+```
 
 Kit will exit if:
 
-- Any job fails.
-- If you requested a specify job, and that completes successfully (e.g. test suite).
+- Any task that cannot be restarted fails.
+- If all requested tasks complete successfully (e.g. test suite) and they should not be restarted.
 - You press `Ctrl+C`.
 
 ### Dependencies
@@ -107,7 +120,8 @@ build:
   command: go build .
 ```
 
-Once a job completes successfully, its downstream task will be started. Once a service is listing on its port, its downstream task are started.
+Once a job completes successfully, its downstream task will be started. Once a service is listing on its port, its
+downstream task are started.
 
 Unlike a plain task, if a service does not start-up (i.e. it is listening on the port), it will be restarted. You can
 specify a probe to determine if the service is running correctly:
@@ -191,7 +205,15 @@ up:
   dependencies: [ deploy ]
 ```
 
-No-op tasks are always succsessful.
+No-op tasks are always successful.
+
+It is common to want to keep kit running when this happens, you can do this by setting the type to `Service`:
+
+```yaml
+up:
+  type: Service
+  dependencies: [ deploy ]
+```
 
 ### Environment Variables
 
@@ -215,9 +237,11 @@ build:
   command: go build .
   watch: src/
 ```
+
 ### Stalled Tasks
 
-Tasks are considered stalled if they do not output anything for 30s by default. You can change this with the `stalledTimeout` field:
+Tasks are considered stalled if they do not output anything for 30s by default. You can change this with the
+`stalledTimeout` field:
 
 ```yaml
 build:

--- a/internal/types/task.go
+++ b/internal/types/task.go
@@ -68,10 +68,6 @@ type Task struct {
 	StalledTimeout *metav1.Duration `json:"stalledTimeout,omitempty"`
 }
 
-func (t Task) IsBackground() bool {
-	return t.GetReadinessProbe() != nil
-}
-
 func (t *Task) GetHostPorts() []uint16 {
 	var ports []uint16
 	for _, p := range t.Ports {
@@ -108,8 +104,8 @@ func (t *Task) GetRestartPolicy() string {
 	if t.RestartPolicy != "" {
 		return t.RestartPolicy
 	}
-	if t.IsBackground() {
-		return "OnFailure"
+	if t.GetType() == TaskTypeService {
+		return "Always"
 	}
 	return "Never"
 }
@@ -125,10 +121,6 @@ func (t *Task) String() string {
 		return t.Args.String()
 	}
 	return "noop"
-}
-
-func (t *Task) IsRestart() bool {
-	return t.IsBackground() && t.GetRestartPolicy() != "Always"
 }
 
 func (t *Task) Environ() ([]string, error) {

--- a/internal/types/workflow_test.go
+++ b/internal/types/workflow_test.go
@@ -18,7 +18,7 @@ func TestPod(t *testing.T) {
 	assert.Len(t, wf.Tasks, 2)
 	task := wf.Tasks["foo"]
 	assert.Equal(t, []uint16{8080}, task.GetHostPorts())
-	assert.Equal(t, "OnFailure", task.GetRestartPolicy())
+	assert.Equal(t, "Always", task.GetRestartPolicy())
 	probe := task.GetReadinessProbe()
 	assert.Equal(t, &Probe{TCPSocket: &TCPSocketAction{Port: 8080}}, probe)
 	assert.Equal(t, 5*time.Second, probe.GetPeriod())


### PR DESCRIPTION
…handling documentation.

Why?

- The changes were made to clarify the behavior of jobs and services regarding their restart policies.
- Improvements were made to the documentation and code to ensure consistency and correctness in task handling.

What changed:

- Updated the README to specify that jobs do not restart on error and introduced the `restartPolicy` setting.
- Clarified the exit conditions for the application in the README.
- Modified the logic in `RunSubgraph` to handle task completion and failure more accurately.
- Removed unnecessary functions and streamlined the `GetRestartPolicy` method in the `Task` struct.