### PR TITLE
feat: change to us exec+ps for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Download the standalone binary from the [releases page](https://github.com/kitpr
 
 ```bash
 # For Linux
-sudo curl --fail --location --output /usr/local/bin/kit https://github.com/kitproj/kit/releases/download/v0.1.103/kit_v0.1.103_linux_386
+sudo curl --fail --location --output /usr/local/bin/kit https://github.com/kitproj/kit/releases/download/v0.1.104/kit_v0.1.104_linux_386
 sudo chmod +x /usr/local/bin/kit
 
 # For Go users
-go install github.com/kitproj/kit@v0.1.103
+go install github.com/kitproj/kit@v0.1.104
 ```
 
 ### Basic Usage

--- a/internal/index.html
+++ b/internal/index.html
@@ -506,7 +506,7 @@
             const formatMetrics = (metrics) => {
                 if (!metrics) return "";
 
-                return `${metrics.cpu.toFixed(0)}m,${(metrics.mem / 1024 / 1024).toFixed(0)}Mi`;
+                return `${(metrics.mem / 1024 / 1024).toFixed(0)}Mi`;
             };
 
             // Fetch the initial graph data from the server

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,50 @@
+package metrics
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/kitproj/kit/internal/types"
+)
+
+func GetCommand(pid int) []string {
+	return []string{"ps", "-o", "%cpu,rss", "-p", strconv.Itoa(pid)}
+}
+
+func ParseOutput(output string) (*types.Metrics, error) {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) < 2 {
+		return nil, fmt.Errorf("unexpected ps output: %s", output)
+	}
+
+	var totalCPU float64
+	var totalMemory uint64
+
+	for i := 1; i < len(lines); i++ {
+		fields := strings.Fields(lines[i])
+		if len(fields) < 2 {
+			continue
+		}
+
+		cpuPercentage, err := strconv.ParseFloat(fields[0], 64)
+		if err != nil {
+			continue
+		}
+
+		rssMemoryKB, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+
+		totalCPU += cpuPercentage
+		totalMemory += uint64(rssMemoryKB * 1024)
+	}
+
+	cpuMillicores := totalCPU * 10
+
+	return &types.Metrics{
+		CPU: uint64(cpuMillicores),
+		Mem: totalMemory,
+	}, nil
+}

--- a/internal/metrics/procfs.go
+++ b/internal/metrics/procfs.go
@@ -1,0 +1,45 @@
+package metrics
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/kitproj/kit/internal/types"
+)
+
+// ProcFSSnapshot contains raw data from /proc/pid/stat for memory tracking
+type ProcFSSnapshot struct {
+	rss uint64 // Memory in bytes
+}
+
+// GetProcFSCommand returns the cat command to read /proc/pid/stat
+func GetProcFSCommand(pid int) []string {
+	return []string{"cat", fmt.Sprintf("/proc/%d/stat", pid)}
+}
+
+// ParseProcFSOutput parses /proc/pid/stat output for memory usage only
+func ParseProcFSOutput(output string, prevSnapshot *ProcFSSnapshot) (*types.Metrics, *ProcFSSnapshot, error) {
+	fields := strings.Fields(strings.TrimSpace(output))
+	if len(fields) < 24 {
+		return nil, nil, fmt.Errorf("unexpected /proc/pid/stat output: insufficient fields")
+	}
+
+	// Field 23 (0-indexed): RSS in pages
+	rssPages, err := strconv.ParseInt(fields[23], 10, 64)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse RSS from /proc/pid/stat: %w", err)
+	}
+
+	// Convert pages to bytes (assuming 4KB page size)
+	memoryBytes := uint64(rssPages * 4096)
+
+	// Create current snapshot
+	currentSnapshot := &ProcFSSnapshot{
+		rss: memoryBytes,
+	}
+
+	return &types.Metrics{
+		Mem: memoryBytes,
+	}, currentSnapshot, nil
+}

--- a/internal/metrics/procfs.go
+++ b/internal/metrics/procfs.go
@@ -17,19 +17,17 @@ func GetProcFSCommand(pid int) []string {
 func ParseProcFSOutput(output string) (*types.Metrics, error) {
 	fields := strings.Fields(strings.TrimSpace(output))
 	if len(fields) < 24 {
-		return nil, nil, fmt.Errorf("unexpected /proc/pid/stat output: insufficient fields")
+		return nil, fmt.Errorf("unexpected /proc/pid/stat output: insufficient fields")
 	}
 
 	// Field 23 (0-indexed): RSS in pages
 	rssPages, err := strconv.ParseInt(fields[23], 10, 64)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse RSS from /proc/pid/stat: %w", err)
+		return nil, fmt.Errorf("failed to parse RSS from /proc/pid/stat: %w", err)
 	}
 
 	// Convert pages to bytes (assuming 4KB page size)
 	memoryBytes := uint64(rssPages * 4096)
 
-	return &types.Metrics{
-		Mem: memoryBytes,
-	}, currentSnapshot, nil
+	return &types.Metrics{Mem: memoryBytes}, nil
 }

--- a/internal/metrics/procfs.go
+++ b/internal/metrics/procfs.go
@@ -8,18 +8,13 @@ import (
 	"github.com/kitproj/kit/internal/types"
 )
 
-// ProcFSSnapshot contains raw data from /proc/pid/stat for memory tracking
-type ProcFSSnapshot struct {
-	rss uint64 // Memory in bytes
-}
-
 // GetProcFSCommand returns the cat command to read /proc/pid/stat
 func GetProcFSCommand(pid int) []string {
 	return []string{"cat", fmt.Sprintf("/proc/%d/stat", pid)}
 }
 
 // ParseProcFSOutput parses /proc/pid/stat output for memory usage only
-func ParseProcFSOutput(output string, prevSnapshot *ProcFSSnapshot) (*types.Metrics, *ProcFSSnapshot, error) {
+func ParseProcFSOutput(output string) (*types.Metrics, error) {
 	fields := strings.Fields(strings.TrimSpace(output))
 	if len(fields) < 24 {
 		return nil, nil, fmt.Errorf("unexpected /proc/pid/stat output: insufficient fields")
@@ -33,11 +28,6 @@ func ParseProcFSOutput(output string, prevSnapshot *ProcFSSnapshot) (*types.Metr
 
 	// Convert pages to bytes (assuming 4KB page size)
 	memoryBytes := uint64(rssPages * 4096)
-
-	// Create current snapshot
-	currentSnapshot := &ProcFSSnapshot{
-		rss: memoryBytes,
-	}
 
 	return &types.Metrics{
 		Mem: memoryBytes,

--- a/internal/metrics/procfs.go
+++ b/internal/metrics/procfs.go
@@ -3,67 +3,11 @@ package metrics
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/kitproj/kit/internal/types"
 )
-
-var (
-	pageSize     int64
-	pageSizeOnce sync.Once
-)
-
-// getSystemPageSize returns the system page size in bytes
-func getSystemPageSize() int64 {
-	pageSizeOnce.Do(func() {
-		pageSize = getPageSizeFromSystem()
-	})
-	return pageSize
-}
-
-// getPageSizeFromSystem determines the system page size using multiple methods
-func getPageSizeFromSystem() int64 {
-	// Method 1: Try using getconf command
-	if cmd := exec.Command("getconf", "PAGESIZE"); cmd != nil {
-		if output, err := cmd.Output(); err == nil {
-			if size, err := strconv.ParseInt(strings.TrimSpace(string(output)), 10, 64); err == nil && size > 0 {
-				return size
-			}
-		}
-	}
-
-	// Method 2: Try reading /proc/meminfo (some systems show page size info)
-	if content, err := os.ReadFile("/proc/meminfo"); err == nil {
-		lines := strings.Split(string(content), "\n")
-		for _, line := range lines {
-			if strings.HasPrefix(line, "Hugepagesize:") {
-				// This won't give us regular page size, but let's check other approaches
-				continue
-			}
-		}
-	}
-
-	// Method 3: Read from /sys/kernel/mm/transparent_hugepage/hpage_pmd_size (if available)
-	// This is for huge pages, not regular pages
-
-	// Method 4: Use common page sizes based on architecture detection
-	// Most x86/x86_64 systems use 4KB pages
-	// Some ARM systems use 16KB or 64KB pages
-	// For now, we'll try to detect through /proc/cpuinfo
-	if content, err := os.ReadFile("/proc/cpuinfo"); err == nil {
-		cpuInfo := string(content)
-		if strings.Contains(cpuInfo, "aarch64") || strings.Contains(cpuInfo, "arm64") {
-			// ARM64 systems often use larger pages, but 4KB is still common
-			// Without more specific detection, we'll fall back to 4KB
-		}
-	}
-
-	// Fallback: Use standard 4KB page size (most common)
-	return 4096
-}
 
 // GetProcFSCommand returns the cat command to read /proc/pid/statm
 func GetProcFSCommand(pid int) []string {
@@ -84,7 +28,7 @@ func ParseProcFSOutput(output string) (*types.Metrics, error) {
 	}
 
 	// Convert pages to bytes using actual system page size
-	systemPageSize := getSystemPageSize()
+	systemPageSize := int64(os.Getpagesize())
 	memoryBytes := uint64(rssPages * systemPageSize)
 
 	return &types.Metrics{Mem: memoryBytes}, nil

--- a/internal/metrics/procfs.go
+++ b/internal/metrics/procfs.go
@@ -2,32 +2,90 @@ package metrics
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/kitproj/kit/internal/types"
 )
 
-// GetProcFSCommand returns the cat command to read /proc/pid/stat
-func GetProcFSCommand(pid int) []string {
-	return []string{"cat", fmt.Sprintf("/proc/%d/stat", pid)}
+var (
+	pageSize     int64
+	pageSizeOnce sync.Once
+)
+
+// getSystemPageSize returns the system page size in bytes
+func getSystemPageSize() int64 {
+	pageSizeOnce.Do(func() {
+		pageSize = getPageSizeFromSystem()
+	})
+	return pageSize
 }
 
-// ParseProcFSOutput parses /proc/pid/stat output for memory usage only
+// getPageSizeFromSystem determines the system page size using multiple methods
+func getPageSizeFromSystem() int64 {
+	// Method 1: Try using getconf command
+	if cmd := exec.Command("getconf", "PAGESIZE"); cmd != nil {
+		if output, err := cmd.Output(); err == nil {
+			if size, err := strconv.ParseInt(strings.TrimSpace(string(output)), 10, 64); err == nil && size > 0 {
+				return size
+			}
+		}
+	}
+
+	// Method 2: Try reading /proc/meminfo (some systems show page size info)
+	if content, err := os.ReadFile("/proc/meminfo"); err == nil {
+		lines := strings.Split(string(content), "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(line, "Hugepagesize:") {
+				// This won't give us regular page size, but let's check other approaches
+				continue
+			}
+		}
+	}
+
+	// Method 3: Read from /sys/kernel/mm/transparent_hugepage/hpage_pmd_size (if available)
+	// This is for huge pages, not regular pages
+
+	// Method 4: Use common page sizes based on architecture detection
+	// Most x86/x86_64 systems use 4KB pages
+	// Some ARM systems use 16KB or 64KB pages
+	// For now, we'll try to detect through /proc/cpuinfo
+	if content, err := os.ReadFile("/proc/cpuinfo"); err == nil {
+		cpuInfo := string(content)
+		if strings.Contains(cpuInfo, "aarch64") || strings.Contains(cpuInfo, "arm64") {
+			// ARM64 systems often use larger pages, but 4KB is still common
+			// Without more specific detection, we'll fall back to 4KB
+		}
+	}
+
+	// Fallback: Use standard 4KB page size (most common)
+	return 4096
+}
+
+// GetProcFSCommand returns the cat command to read /proc/pid/statm
+func GetProcFSCommand(pid int) []string {
+	return []string{"cat", fmt.Sprintf("/proc/%d/statm", pid)}
+}
+
+// ParseProcFSOutput parses /proc/pid/statm output for memory usage only
 func ParseProcFSOutput(output string) (*types.Metrics, error) {
 	fields := strings.Fields(strings.TrimSpace(output))
-	if len(fields) < 24 {
-		return nil, fmt.Errorf("unexpected /proc/pid/stat output: insufficient fields")
+	if len(fields) < 2 {
+		return nil, fmt.Errorf("unexpected /proc/pid/statm output: insufficient fields")
 	}
 
-	// Field 23 (0-indexed): RSS in pages
-	rssPages, err := strconv.ParseInt(fields[23], 10, 64)
+	// Field 1 (0-indexed): RSS (resident pages)
+	rssPages, err := strconv.ParseInt(fields[1], 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse RSS from /proc/pid/stat: %w", err)
+		return nil, fmt.Errorf("failed to parse RSS from /proc/pid/statm: %w", err)
 	}
 
-	// Convert pages to bytes (assuming 4KB page size)
-	memoryBytes := uint64(rssPages * 4096)
+	// Convert pages to bytes using actual system page size
+	systemPageSize := getSystemPageSize()
+	memoryBytes := uint64(rssPages * systemPageSize)
 
 	return &types.Metrics{Mem: memoryBytes}, nil
 }

--- a/internal/metrics/ps.go
+++ b/internal/metrics/ps.go
@@ -8,43 +8,33 @@ import (
 	"github.com/kitproj/kit/internal/types"
 )
 
-func GetCommand(pid int) []string {
-	return []string{"ps", "-o", "%cpu,rss", "-p", strconv.Itoa(pid)}
+func GetPSCommand(pid int) []string {
+	return []string{"ps", "-o", "rss", "-p", strconv.Itoa(pid)}
 }
 
-func ParseOutput(output string) (*types.Metrics, error) {
+func ParsePSOutput(output string) (*types.Metrics, error) {
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 	if len(lines) < 2 {
 		return nil, fmt.Errorf("unexpected ps output: %s", output)
 	}
 
-	var totalCPU float64
 	var totalMemory uint64
 
 	for i := 1; i < len(lines); i++ {
 		fields := strings.Fields(lines[i])
-		if len(fields) < 2 {
+		if len(fields) < 1 {
 			continue
 		}
 
-		cpuPercentage, err := strconv.ParseFloat(fields[0], 64)
+		rssMemoryKB, err := strconv.ParseInt(fields[0], 10, 64)
 		if err != nil {
 			continue
 		}
 
-		rssMemoryKB, err := strconv.ParseInt(fields[1], 10, 64)
-		if err != nil {
-			continue
-		}
-
-		totalCPU += cpuPercentage
 		totalMemory += uint64(rssMemoryKB * 1024)
 	}
 
-	cpuMillicores := totalCPU * 10
-
 	return &types.Metrics{
-		CPU: uint64(cpuMillicores),
 		Mem: totalMemory,
 	}, nil
 }

--- a/internal/proc/container.go
+++ b/internal/proc/container.go
@@ -315,9 +315,9 @@ func (c *container) GetMetrics(ctx context.Context) (*types.Metrics, error) {
 	command := metrics.GetProcFSCommand(1) // PID 1
 	cmdArgs := append([]string{"exec", c.name}, command...)
 	cmd := exec.CommandContext(ctx, "docker", cmdArgs...)
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("docker exec ps failed for container %s: %w", c.name, err)
+		return nil, fmt.Errorf("docker exec ps failed for container %s: %w, output: %s", c.name, err, string(output))
 	}
 
 	metrics, err := metrics.ParseProcFSOutput(string(output))

--- a/internal/proc/container.go
+++ b/internal/proc/container.go
@@ -37,8 +37,7 @@ type container struct {
 	log  *log.Logger
 	spec types.Spec
 	types.Task
-	containerID    string
-	profFSSnapshot *metrics.ProcFSSnapshot
+	containerID string
 }
 
 func (c *container) Run(ctx context.Context, stdout, stderr io.Writer) error {
@@ -321,11 +320,10 @@ func (c *container) GetMetrics(ctx context.Context) (*types.Metrics, error) {
 		return nil, fmt.Errorf("docker exec ps failed for container %s: %w", c.name, err)
 	}
 
-	metrics, procFSSnapshot, err := metrics.ParseProcFSOutput(string(output), c.profFSSnapshot)
+	metrics, err := metrics.ParseProcFSOutput(string(output))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse process metrics for container %s: %w", c.name, err)
 	}
-	c.profFSSnapshot = procFSSnapshot
 	return metrics, nil
 }
 

--- a/internal/proc/container.go
+++ b/internal/proc/container.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/registry"
 	"github.com/docker/go-connections/nat"
+	"github.com/kitproj/kit/internal/metrics"
 	"github.com/kitproj/kit/internal/types"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"k8s.io/utils/strings/slices"
@@ -310,50 +312,15 @@ func (c *container) GetMetrics(ctx context.Context) (*types.Metrics, error) {
 		return &types.Metrics{}, nil
 	}
 
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	command := metrics.GetCommand(1) // PID 1
+	cmdArgs := append([]string{"exec", c.name}, command...)
+	cmd := exec.CommandContext(ctx, "docker", cmdArgs...)
+	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create docker client: %w", err)
-	}
-	defer cli.Close()
-
-	stats, err := cli.ContainerStats(ctx, c.containerID, false) // false = single stat, not stream
-	if err != nil {
-		return nil, fmt.Errorf("failed to get container stats: %w", err)
-	}
-	defer stats.Body.Close()
-
-	data, err := io.ReadAll(stats.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read stats: %w", err)
+		return nil, fmt.Errorf("docker exec ps failed for container %s: %w", c.name, err)
 	}
 
-	var dockerStats dockertypes.StatsJSON
-	if err := json.Unmarshal(data, &dockerStats); err != nil {
-		return nil, fmt.Errorf("failed to parse stats: %w", err)
-	}
-
-	// Calculate memory usage (subtract cache if available)
-	memoryBytes := dockerStats.MemoryStats.Usage
-	if dockerStats.MemoryStats.Stats["cache"] != 0 {
-		memoryBytes -= dockerStats.MemoryStats.Stats["cache"]
-	}
-
-	// Calculate CPU usage in millicores
-	var cpuMillicores uint64
-	if dockerStats.PreCPUStats.CPUUsage.TotalUsage != 0 {
-		cpuDelta := dockerStats.CPUStats.CPUUsage.TotalUsage - dockerStats.PreCPUStats.CPUUsage.TotalUsage
-		systemDelta := dockerStats.CPUStats.SystemUsage - dockerStats.PreCPUStats.SystemUsage
-
-		if systemDelta > 0 {
-			cpuPercent := (float64(cpuDelta) / float64(systemDelta)) * float64(len(dockerStats.CPUStats.CPUUsage.PercpuUsage))
-			cpuMillicores = uint64(cpuPercent * 1000) // Convert to millicores
-		}
-	}
-
-	return &types.Metrics{
-		CPU: cpuMillicores,
-		Mem: memoryBytes,
-	}, nil
+	return metrics.ParseOutput(string(output))
 }
 
 var _ Interface = &container{}

--- a/internal/proc/host.go
+++ b/internal/proc/host.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -90,8 +90,8 @@ func ignoreProcessFinishedErr(err error) error {
 }
 
 func (h *host) GetMetrics(ctx context.Context) (*types.Metrics, error) {
-	command, args := metrics.GetCommand(h.pid)
-	cmd := exec.CommandContext(ctx, command, args...)
+	command := metrics.GetCommand(h.pid)
+	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/proc/host.go
+++ b/internal/proc/host.go
@@ -93,9 +93,9 @@ func (h *host) GetMetrics(ctx context.Context) (*types.Metrics, error) {
 	command := metrics.GetPSCommand(h.pid)
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get process metrics for pid %d: %w", h.pid, err)
+		return nil, fmt.Errorf("failed to get process metrics for pid %d: %w, output: %s", h.pid, err, string(output))
 	}
 
 	return metrics.ParsePSOutput(string(output))

--- a/internal/proc/host.go
+++ b/internal/proc/host.go
@@ -19,7 +19,8 @@ type host struct {
 	log  *log.Logger
 	spec types.Spec
 	types.Task
-	pid int
+	pid            int
+	profFSSnapshot *metrics.ProcFSSnapshot
 }
 
 func (h *host) Run(ctx context.Context, stdout, stderr io.Writer) error {
@@ -90,7 +91,7 @@ func ignoreProcessFinishedErr(err error) error {
 }
 
 func (h *host) GetMetrics(ctx context.Context) (*types.Metrics, error) {
-	command := metrics.GetCommand(h.pid)
+	command := metrics.GetPSCommand(h.pid)
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
 
 	output, err := cmd.Output()
@@ -98,5 +99,5 @@ func (h *host) GetMetrics(ctx context.Context) (*types.Metrics, error) {
 		return nil, fmt.Errorf("failed to get process metrics for pid %d: %w", h.pid, err)
 	}
 
-	return metrics.ParseOutput(string(output))
+	return metrics.ParsePSOutput(string(output))
 }

--- a/internal/proc/host.go
+++ b/internal/proc/host.go
@@ -19,8 +19,7 @@ type host struct {
 	log  *log.Logger
 	spec types.Spec
 	types.Task
-	pid            int
-	profFSSnapshot *metrics.ProcFSSnapshot
+	pid int
 }
 
 func (h *host) Run(ctx context.Context, stdout, stderr io.Writer) error {

--- a/internal/proc/host.go
+++ b/internal/proc/host.go
@@ -8,10 +8,10 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
+	"github.com/kitproj/kit/internal/metrics"
 	"github.com/kitproj/kit/internal/types"
 )
 
@@ -90,50 +90,13 @@ func ignoreProcessFinishedErr(err error) error {
 }
 
 func (h *host) GetMetrics(ctx context.Context) (*types.Metrics, error) {
+	command, args := metrics.GetCommand(h.pid)
+	cmd := exec.CommandContext(ctx, command, args...)
 
-	// The `ps` command is used to get process information.
-	// -o %cpu,%mem specifies the desired output format: CPU and memory percentage.
-	// -p filters the output for the given PID.
-	cmd := exec.CommandContext(ctx, "ps", "-o", "%cpu,rss", "-p", strconv.Itoa(h.pid))
-
-	// Execute the command and capture its output.
 	output, err := cmd.Output()
 	if err != nil {
-		// This error typically occurs if the PID does not exist.
 		return nil, fmt.Errorf("failed to get process metrics for pid %d: %w", h.pid, err)
 	}
 
-	// The output from `ps` includes a header line, so we need to parse the second line.
-	// Example output:
-	// %CPU %MEM
-	//  0.1  0.2
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	if len(lines) < 2 {
-		return nil, fmt.Errorf("unexpected ps output for pid %d: %s", h.pid, output)
-	}
-
-	// The second line contains the data. We split it by whitespace.
-	fields := strings.Fields(lines[1])
-	if len(fields) < 2 {
-		return nil, fmt.Errorf("unexpected ps output format for pid %d: %s", h.pid, lines[1])
-	}
-
-	// Parse the CPU usage from the first field.
-	cpuPercentage, err := strconv.ParseFloat(fields[0], 64)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse CPU usage '%s': %w", fields[0], err)
-	}
-
-	cpuMillicores := cpuPercentage * 10 // Convert percentage to millicores (1% = 10 millicores)
-
-	rssMemoryKB, err := strconv.ParseInt(fields[1], 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse RSS memory '%s': %w", fields[1], err)
-	}
-
-	// Convert RSS memoryBytes from KB to bytes.
-	memoryBytes := uint64(rssMemoryKB * 1024)
-
-	return &types.Metrics{CPU: uint64(cpuMillicores), Mem: memoryBytes}, nil
-
+	return metrics.ParseOutput(string(output))
 }

--- a/internal/proc/kubernetes.go
+++ b/internal/proc/kubernetes.go
@@ -44,7 +44,6 @@ type k8s struct {
 	name string
 	pods []string // namespace/name
 	types.Task
-	profFSSnapshot *metrics.ProcFSSnapshot
 }
 
 // previously we used the K8s common labels, but because charts use them themselves (e.g. Helm) we cannot and must create our own annotations
@@ -458,10 +457,9 @@ func (k *k8s) getMetrics(ctx context.Context, namespace, podName string) (*types
 		return nil, fmt.Errorf("failed to run %q: %w", strings.Join(cmd.Args, " "), err)
 	}
 
-	metrics, procFSSnapshot, err := metrics.ParseProcFSOutput(string(output), k.profFSSnapshot)
+	metrics, err := metrics.ParseProcFSOutput(string(output))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse process metrics for pid: %w", err)
 	}
-	k.profFSSnapshot = procFSSnapshot
 	return metrics, nil
 }

--- a/internal/proc/kubernetes.go
+++ b/internal/proc/kubernetes.go
@@ -450,9 +450,8 @@ func (k *k8s) GetMetrics(ctx context.Context) (*types.Metrics, error) {
 }
 
 func (k *k8s) getMetrics(ctx context.Context, namespace, podName string) (*types.Metrics, error) {
-	command, args := metrics.GetAllProcessesCommand()
-	cmdArgs := append([]string{"exec", "-n", namespace, podName, "--"}, command)
-	cmdArgs = append(cmdArgs, args...)
+	command := metrics.GetCommand(1) // PID 1
+	cmdArgs := append([]string{"exec", "-n", namespace, podName, "--"}, command...)
 	cmd := exec.CommandContext(ctx, "kubectl", cmdArgs...)
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/types/metrics.go
+++ b/internal/types/metrics.go
@@ -1,6 +1,5 @@
 package types
 
 type Metrics struct {
-	CPU uint64 `json:"cpu"` // CPU usage in millicores
 	Mem uint64 `json:"mem"` // Memory usage in bytes
 }

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -42,7 +42,7 @@ tasks:
     manifests:
       - testdata
     ports:
-      - 80:8080
+      - 18080:80
   script:
     sh: |
       set -eu


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics UI now shows memory usage only; CPU is no longer displayed.
* **Documentation**
  * Quick Start updated to reference release v0.1.104.
* **Refactor**
  * Metrics collection unified across local, Docker, and Kubernetes to standardize memory reporting.
* **Chores**
  * Default host port for the Kubernetes run task changed to 18080 → 80 (container).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->